### PR TITLE
Move to Qt6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ moc_*
 *.moc
 qmlfilemuncher
 qrc_data.cpp
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,18 +13,30 @@ set(CMAKE_INSTALL_PREFIX /usr)
 include(FeatureSummary)
 include(GNUInstallDirs)
 
-set(INSTALL_QML_IMPORT_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/qt/qml"
-	CACHE PATH "Custom QML import installation directory")
+function(FindQtInstallQml)
+    find_program(QMAKE NAMES qmake6 qmake)
+    if(NOT QMAKE)
+        message(FATAL_ERROR "qmake not found")
+    endif()
+    execute_process(
+        COMMAND ${QMAKE} -query QT_INSTALL_QML
+        OUTPUT_VARIABLE PROC_RESULT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set(QT_INSTALL_QML ${PROC_RESULT} PARENT_SCOPE)
+endfunction()
 
-set(QT_MIN_VERSION "5.6.0")
-find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS Gui Qml Quick LinguistTools REQUIRED)
+FindQtInstallQml()
+
+set(QT_MIN_VERSION "6.0.0")
+find_package(Qt6 ${QT_MIN_VERSION} COMPONENTS Gui Qml Quick LinguistTools REQUIRED)
 find_package(Glacier COMPONENTS App REQUIRED)
 
 add_subdirectory(src)
 
 # Translations
 file(GLOB TS_FILES translations/*.ts)
-qt5_add_translation(QM_FILES ${TS_FILES})
+qt_add_translation(QM_FILES ${TS_FILES})
 add_custom_target(translations DEPENDS ${QM_FILES})
 add_dependencies(glacier-filemuncher translations)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,9 +8,9 @@ set(HEADERS filetools.h
 add_executable(glacier-filemuncher ${SRC} ${HEADERS})
 
 target_link_libraries(glacier-filemuncher
-	Qt5::Gui
-	Qt5::Qml
-	Qt5::Quick
+	Qt6::Gui
+	Qt6::Qml
+	Qt6::Quick
 	Glacier::App)
 
 install(TARGETS glacier-filemuncher RUNTIME
@@ -19,5 +19,5 @@ install(DIRECTORY qml
 	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/glacier-filemuncher
 	PATTERN "api" EXCLUDE)
 install(DIRECTORY qml/api/
-	DESTINATION
-	${INSTALL_QML_IMPORT_DIR}/org/nemomobile/filemuncher)
+	DESTINATION ${QT_INSTALL_QML}/org/nemomobile/filemuncher/
+)

--- a/src/qml/DetailViewSheet.qml
+++ b/src/qml/DetailViewSheet.qml
@@ -30,11 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 Page {
     id: sheet

--- a/src/qml/DirectoryPage.qml
+++ b/src/qml/DirectoryPage.qml
@@ -30,16 +30,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-import QtQuick 2.6
+import QtQuick
 
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import Nemo.Controls
+import Nemo.Dialogs
 
-import Nemo.Dialogs 1.0
-
-import org.nemomobile.folderlistmodel 1.0
-import org.nemomobile.filemuncher 1.0
+import org.nemomobile.folderlistmodel
+import org.nemomobile.filemuncher
 
 Page {
     id: page
@@ -116,7 +113,7 @@ Page {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             smooth: true
-            textColor: Theme.textColor
+    //        textColor: Theme.textColor
             text: dirModel.path
             onAccepted: {
                 if (text === '') {

--- a/src/qml/FilePickerSheet.qml
+++ b/src/qml/FilePickerSheet.qml
@@ -30,11 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 Sheet {
     id: sheet

--- a/src/qml/InputSheet.qml
+++ b/src/qml/InputSheet.qml
@@ -30,11 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 Page {
     id: sheet

--- a/src/qml/TextViewPage.qml
+++ b/src/qml/TextViewPage.qml
@@ -29,13 +29,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
-
-import org.nemomobile.glacier.filemuncher 1.0
+import QtQuick
+import Nemo.Controls
+import org.nemomobile.glacier.filemuncher
 
 Page {
     id: textViewPage

--- a/src/qml/api/FileListDelegate.qml
+++ b/src/qml/api/FileListDelegate.qml
@@ -30,11 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 ListViewItemWithActions {
     id: delegate

--- a/src/qml/api/FilePermissionIndicator.qml
+++ b/src/qml/api/FilePermissionIndicator.qml
@@ -30,11 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
+import QtQuick
+import Nemo.Controls
 
 Rectangle {
     property int pixelSize

--- a/src/qml/glacier-filemuncher.qml
+++ b/src/qml/glacier-filemuncher.qml
@@ -30,13 +30,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-import QtQuick 2.6
-
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Nemo 1.0
-import QtQuick.Controls.Styles.Nemo 1.0
-
-import Nemo.Thumbnailer 1.0
+import QtQuick
+import Nemo.Controls
+//import Nemo.Thumbnailer
 
 ApplicationWindow {
     id: window


### PR DESCRIPTION
The compatibility with Qt5 is not introduced, because the .qml files aren't compatible anyway

![Screenshot_manjaro_2023-07-08_12:53:30](https://github.com/nemomobile-ux/glacier-filemuncher/assets/6171637/af782988-3ff0-4d37-930e-a67374d441e3)
